### PR TITLE
Add Screenshot Sweeper macOS menu bar app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ScreenshotSweeper",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "ScreenshotSweeper", targets: ["ScreenshotSweeper"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ScreenshotSweeper",
+            path: "Sources/ScreenshotSweeper",
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("SwiftUI")
+            ]
+        )
+    ]
+)

--- a/Sources/ScreenshotSweeper/Models/Settings.swift
+++ b/Sources/ScreenshotSweeper/Models/Settings.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct Settings: Codable {
+    enum DestinationMode: Codable {
+        case trash
+        case folder(bookmark: Data)
+    }
+
+    var cleanupEnabled: Bool = true
+    /// Stored as hour/minute components.
+    var cleanupTime: DateComponents = DateComponents(hour: 23, minute: 59)
+    var destinationMode: DestinationMode = .trash
+    var prefix: String = "Screenshot"
+    var isCaseSensitive: Bool = true
+    var totalCleaned: Int = 0
+}
+
+extension Settings {
+    private static let defaultsKey = "settings"
+
+    static func load() -> Settings {
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: defaultsKey),
+           let s = try? JSONDecoder().decode(Settings.self, from: data) {
+            return s
+        }
+        return Settings()
+    }
+
+    func save() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
+++ b/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import os.log
+
+@main
+struct ScreenshotSweeperApp: App {
+    @StateObject private var viewModel = AppViewModel()
+    @State private var showingPreferences = false
+
+    var body: some Scene {
+        MenuBarExtra("Screenshot Sweeper", systemImage: "scissors") {
+            MenuBarView(viewModel: viewModel, showingPreferences: $showingPreferences)
+        }
+        .menuBarExtraStyle(.window)
+        .sheet(isPresented: $showingPreferences) {
+            PreferencesView(viewModel: viewModel)
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/CleanupService.swift
+++ b/Sources/ScreenshotSweeper/Services/CleanupService.swift
@@ -1,0 +1,63 @@
+import Foundation
+import os.log
+
+struct CleanupService {
+    enum Destination {
+        case trash
+        case folder(URL)
+    }
+
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "Cleanup")
+
+    func performCleanup(prefix: String, isCaseSensitive: Bool, destination: Destination) -> Int {
+        let fm = FileManager.default
+        guard let desktop = fm.urls(for: .desktopDirectory, in: .userDomainMask).first else {
+            logger.error("Could not resolve Desktop directory")
+            return 0
+        }
+        let exts = ["png", "jpg", "jpeg", "heic", "tiff"]
+        var cleaned = 0
+        do {
+            let items = try fm.contentsOfDirectory(at: desktop, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            for url in items {
+                guard exts.contains(url.pathExtension.lowercased()) else { continue }
+                let name = url.lastPathComponent
+                let matches: Bool
+                if isCaseSensitive {
+                    matches = name.hasPrefix(prefix)
+                } else {
+                    matches = name.lowercased().hasPrefix(prefix.lowercased())
+                }
+                guard matches else { continue }
+                do {
+                    switch destination {
+                    case .trash:
+                        try fm.trashItem(at: url, resultingItemURL: nil)
+                    case .folder(let folderURL):
+                        let dest = conflictSafeURL(for: url, in: folderURL)
+                        try fm.moveItem(at: url, to: dest)
+                    }
+                    cleaned += 1
+                } catch {
+                    logger.error("Failed to move \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        } catch {
+            logger.error("Error reading Desktop: \(error.localizedDescription, privacy: .public)")
+        }
+        return cleaned
+    }
+
+    private func conflictSafeURL(for url: URL, in folder: URL) -> URL {
+        let fm = FileManager.default
+        var dest = folder.appendingPathComponent(url.lastPathComponent)
+        var counter = 1
+        while fm.fileExists(atPath: dest.path) {
+            let base = url.deletingPathExtension().lastPathComponent
+            let ext = url.pathExtension
+            dest = folder.appendingPathComponent("\(base)-\(counter).\(ext)")
+            counter += 1
+        }
+        return dest
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/FolderAccess.swift
+++ b/Sources/ScreenshotSweeper/Services/FolderAccess.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+enum FolderAccess {
+    static func selectFolder() -> Data? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Select"
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return nil }
+        do {
+            let bookmark = try url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
+            return bookmark
+        } catch {
+            return nil
+        }
+    }
+
+    static func resolveBookmark(_ data: Data) -> URL? {
+        var isStale = false
+        return try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &isStale)
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/Scheduler.swift
+++ b/Sources/ScreenshotSweeper/Services/Scheduler.swift
@@ -1,0 +1,21 @@
+import Foundation
+import os.log
+
+final class Scheduler {
+    private var timer: Timer?
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "Scheduler")
+
+    func schedule(at date: Date, handler: @escaping () -> Void) {
+        timer?.invalidate()
+        let interval = max(date.timeIntervalSinceNow, 1)
+        logger.debug("Scheduling cleanup in \(interval, privacy: .public) seconds")
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { _ in
+            handler()
+        }
+    }
+
+    func invalidate() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
+++ b/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+import os.log
+
+final class AppViewModel: ObservableObject {
+    @Published var settings: Settings
+    private let scheduler = Scheduler()
+    private let cleanupService = CleanupService()
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "ViewModel")
+
+    init() {
+        settings = Settings.load()
+        scheduleCleanup()
+    }
+
+    func cleanNow() {
+        let destination: CleanupService.Destination
+        switch settings.destinationMode {
+        case .trash:
+            destination = .trash
+        case .folder(let bookmark):
+            if let url = FolderAccess.resolveBookmark(bookmark) {
+                destination = .folder(url)
+            } else {
+                logger.error("Folder bookmark invalid; defaulting to trash")
+                destination = .trash
+            }
+        }
+
+        let count = cleanupService.performCleanup(prefix: settings.prefix, isCaseSensitive: settings.isCaseSensitive, destination: destination)
+        if count > 0 {
+            settings.totalCleaned += count
+            settings.save()
+        }
+    }
+
+    private func scheduleCleanup() {
+        guard settings.cleanupEnabled else { return }
+        let next = nextCleanupDate()
+        scheduler.schedule(at: next) { [weak self] in
+            self?.cleanNow()
+            self?.scheduleCleanup()
+        }
+    }
+
+    private func nextCleanupDate() -> Date {
+        var comps = settings.cleanupTime
+        let cal = Calendar.current
+        var date = cal.date(bySettingHour: comps.hour ?? 23, minute: comps.minute ?? 59, second: 0, of: Date()) ?? Date()
+        if date < Date() {
+            date = cal.date(byAdding: .day, value: 1, to: date) ?? date
+        }
+        return date
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/MenuBarView.swift
+++ b/Sources/ScreenshotSweeper/Views/MenuBarView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct MenuBarView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @Binding var showingPreferences: Bool
+    @State private var confirmCleanup = false
+
+    var body: some View {
+        VStack {
+            Text("Total cleaned: \(viewModel.settings.totalCleaned)")
+                .padding(.horizontal)
+            Divider()
+            Button("Clean Now…") {
+                confirmCleanup = true
+            }
+            .alert("Clean Desktop Screenshots?", isPresented: $confirmCleanup) {
+                Button("Cancel", role: .cancel) {}
+                Button("Clean", role: .destructive) {
+                    viewModel.cleanNow()
+                }
+            } message: {
+                Text("This will move matching screenshots according to your settings.")
+            }
+            Divider()
+            Button("Preferences…") {
+                showingPreferences = true
+            }
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/PreferencesView.swift
+++ b/Sources/ScreenshotSweeper/Views/PreferencesView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        Text("Preferences go here")
+            .padding()
+            // TODO: Build out UI in later prompt
+    }
+}


### PR DESCRIPTION
## Summary
- add Swift Package skeleton for Screenshot Sweeper macOS menu bar utility
- implement desktop screenshot cleanup service with Trash or folder destinations
- wire up SwiftUI menu bar interface, scheduling, and preferences placeholder

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b1daeebc6c832aa2d98d7bfd8ff71e