### PR TITLE
Polish menu bar UI with preferences and cleanup confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ScreenshotSweeper",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "ScreenshotSweeper", targets: ["ScreenshotSweeper"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ScreenshotSweeper",
+            path: "Sources/ScreenshotSweeper",
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("SwiftUI")
+            ]
+        )
+    ]
+)

--- a/Sources/ScreenshotSweeper/Models/Settings.swift
+++ b/Sources/ScreenshotSweeper/Models/Settings.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct Settings: Codable {
+    enum DestinationMode: Codable {
+        case trash
+        case folder(bookmark: Data)
+    }
+
+    var cleanupEnabled: Bool = true
+    /// Stored as hour/minute components.
+    var cleanupTime: DateComponents = DateComponents(hour: 23, minute: 59)
+    var destinationMode: DestinationMode = .trash
+    var prefix: String = "Screenshot"
+    var isCaseSensitive: Bool = true
+    var totalCleaned: Int = 0
+    var lastRun: Date? = nil
+}
+
+extension Settings {
+    private static let defaultsKey = "settings"
+
+    static func load() -> Settings {
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: defaultsKey),
+           let s = try? JSONDecoder().decode(Settings.self, from: data) {
+            return s
+        }
+        return Settings()
+    }
+
+    func save() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
+++ b/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import os.log
+
+@main
+struct ScreenshotSweeperApp: App {
+    @StateObject private var viewModel = AppViewModel()
+    @State private var showingPreferences = false
+
+    var body: some Scene {
+        MenuBarExtra("Screenshot Sweeper", systemImage: "camera.fill.badge.ellipsis") {
+            MenuBarView(viewModel: viewModel, showingPreferences: $showingPreferences)
+        }
+        .menuBarExtraStyle(.window)
+        .sheet(isPresented: $showingPreferences) {
+            PreferencesView(viewModel: viewModel)
+        }
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button(NSLocalizedString("Preferences…", comment: "command")) {
+                    showingPreferences = true
+                }
+                .keyboardShortcut(",", modifiers: [.command])
+            }
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/CleanupService.swift
+++ b/Sources/ScreenshotSweeper/Services/CleanupService.swift
@@ -1,0 +1,73 @@
+import Foundation
+import os.log
+
+struct CleanupService {
+    enum Destination {
+        case trash
+        case folder(URL)
+    }
+
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "Cleanup")
+
+    func performCleanup(prefix: String, isCaseSensitive: Bool, destination: Destination) -> Int {
+        let fm = FileManager.default
+        let urls = screenshotURLs(prefix: prefix, isCaseSensitive: isCaseSensitive)
+        var cleaned = 0
+        for url in urls {
+            do {
+                switch destination {
+                case .trash:
+                    try fm.trashItem(at: url, resultingItemURL: nil)
+                case .folder(let folderURL):
+                    let dest = conflictSafeURL(for: url, in: folderURL)
+                    try fm.moveItem(at: url, to: dest)
+                }
+                cleaned += 1
+            } catch {
+                logger.error("Failed to move \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        return cleaned
+    }
+
+    func matchingScreenshotCount(prefix: String, isCaseSensitive: Bool) -> Int {
+        screenshotURLs(prefix: prefix, isCaseSensitive: isCaseSensitive).count
+    }
+
+    private func screenshotURLs(prefix: String, isCaseSensitive: Bool) -> [URL] {
+        let fm = FileManager.default
+        guard let desktop = fm.urls(for: .desktopDirectory, in: .userDomainMask).first else {
+            logger.error("Could not resolve Desktop directory")
+            return []
+        }
+        let exts = ["png", "jpg", "jpeg", "heic", "tiff"]
+        do {
+            let items = try fm.contentsOfDirectory(at: desktop, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            return items.filter { url in
+                guard exts.contains(url.pathExtension.lowercased()) else { return false }
+                let name = url.lastPathComponent
+                if isCaseSensitive {
+                    return name.hasPrefix(prefix)
+                } else {
+                    return name.lowercased().hasPrefix(prefix.lowercased())
+                }
+            }
+        } catch {
+            logger.error("Error reading Desktop: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+
+    private func conflictSafeURL(for url: URL, in folder: URL) -> URL {
+        let fm = FileManager.default
+        var dest = folder.appendingPathComponent(url.lastPathComponent)
+        var counter = 1
+        while fm.fileExists(atPath: dest.path) {
+            let base = url.deletingPathExtension().lastPathComponent
+            let ext = url.pathExtension
+            dest = folder.appendingPathComponent("\(base)-\(counter).\(ext)")
+            counter += 1
+        }
+        return dest
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/FolderAccess.swift
+++ b/Sources/ScreenshotSweeper/Services/FolderAccess.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+enum FolderAccess {
+    static func selectFolder() -> Data? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Select"
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return nil }
+        do {
+            let bookmark = try url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
+            return bookmark
+        } catch {
+            return nil
+        }
+    }
+
+    static func resolveBookmark(_ data: Data) -> URL? {
+        var isStale = false
+        return try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &isStale)
+    }
+}

--- a/Sources/ScreenshotSweeper/Services/Scheduler.swift
+++ b/Sources/ScreenshotSweeper/Services/Scheduler.swift
@@ -1,0 +1,21 @@
+import Foundation
+import os.log
+
+final class Scheduler {
+    private var timer: Timer?
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "Scheduler")
+
+    func schedule(at date: Date, handler: @escaping () -> Void) {
+        timer?.invalidate()
+        let interval = max(date.timeIntervalSinceNow, 1)
+        logger.debug("Scheduling cleanup in \(interval, privacy: .public) seconds")
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { _ in
+            handler()
+        }
+    }
+
+    func invalidate() {
+        timer?.invalidate()
+        timer = nil
+    }
+}

--- a/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
+++ b/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftUI
+import os.log
+
+final class AppViewModel: ObservableObject {
+    @Published var settings: Settings
+    @Published var matchCount: Int = 0
+    private let scheduler = Scheduler()
+    private let cleanupService = CleanupService()
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "ViewModel")
+
+    init() {
+        settings = Settings.load()
+        refreshMatchCount()
+        scheduleCleanup()
+    }
+
+    @discardableResult
+    func cleanNow() -> Int {
+        let destination: CleanupService.Destination
+        switch settings.destinationMode {
+        case .trash:
+            destination = .trash
+        case .folder(let bookmark):
+            if let url = FolderAccess.resolveBookmark(bookmark) {
+                destination = .folder(url)
+            } else {
+                logger.error("Folder bookmark invalid; defaulting to trash")
+                destination = .trash
+            }
+        }
+
+        let count = cleanupService.performCleanup(prefix: settings.prefix, isCaseSensitive: settings.isCaseSensitive, destination: destination)
+        settings.lastRun = Date()
+        if count > 0 {
+            settings.totalCleaned += count
+        }
+        settings.save()
+        refreshMatchCount()
+        return count
+    }
+
+    func refreshMatchCount() {
+        matchCount = cleanupService.matchingScreenshotCount(prefix: settings.prefix, isCaseSensitive: settings.isCaseSensitive)
+    }
+
+    func updateSchedule() {
+        scheduler.invalidate()
+        scheduleCleanup()
+    }
+
+    private func scheduleCleanup() {
+        guard settings.cleanupEnabled else { return }
+        let next = nextCleanupDate()
+        scheduler.schedule(at: next) { [weak self] in
+            guard let self = self else { return }
+            let count = self.cleanNow()
+            self.logger.info("Scheduled cleanup removed \(count, privacy: .public) items")
+            self.scheduleCleanup()
+        }
+    }
+
+    private func nextCleanupDate() -> Date {
+        var comps = settings.cleanupTime
+        let cal = Calendar.current
+        var date = cal.date(bySettingHour: comps.hour ?? 23, minute: comps.minute ?? 59, second: 0, of: Date()) ?? Date()
+        if date < Date() {
+            date = cal.date(byAdding: .day, value: 1, to: date) ?? date
+        }
+        return date
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/ConfirmCleanupView.swift
+++ b/Sources/ScreenshotSweeper/Views/ConfirmCleanupView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ConfirmCleanupView: View {
+    let count: Int
+    let destinationDescription: String
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+    @State private var acknowledged = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(String(format: NSLocalizedString("You're about to clean %d screenshot%@ from Desktop.", comment: "summary"), count, count == 1 ? "" : "s"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Toggle(isOn: $acknowledged) {
+                Text(String(format: NSLocalizedString("I understand these files will be moved to %@", comment: "confirmation"), destinationDescription))
+            }
+            .toggleStyle(.checkbox)
+            HStack {
+                Button(NSLocalizedString("Cancel", comment: "cancel")) {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button(NSLocalizedString("Confirm", comment: "confirm")) {
+                    onConfirm()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!acknowledged)
+            }
+        }
+        .padding(20)
+        .frame(width: 320)
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/MenuBarView.swift
+++ b/Sources/ScreenshotSweeper/Views/MenuBarView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import AppKit
+
+struct MenuBarView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @Binding var showingPreferences: Bool
+    @State private var showingConfirm = false
+    @State private var toastMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button(NSLocalizedString("Clean Now…", comment: "menu")) {
+                viewModel.refreshMatchCount()
+                showingConfirm = true
+            }
+            if let toastMessage {
+                Text(toastMessage)
+                    .font(.footnote)
+                    .padding(.vertical, 4)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.secondary.opacity(0.1))
+                    .transition(.move(edge: .top))
+            }
+
+            Text(String(format: NSLocalizedString("Total cleaned (all-time): %d", comment: "status"), viewModel.settings.totalCleaned))
+            Text(String(format: NSLocalizedString("Last run: %@", comment: "status"), lastRunText()))
+
+            Divider()
+
+            Toggle(NSLocalizedString("Daily cleanup", comment: "toggle"), isOn: $viewModel.settings.cleanupEnabled)
+                .onChange(of: viewModel.settings.cleanupEnabled) { _ in
+                    viewModel.settings.save()
+                    viewModel.updateSchedule()
+                }
+
+            Button(NSLocalizedString("Open Preferences…", comment: "menu")) {
+                showingPreferences = true
+            }
+            Button(NSLocalizedString("Quit Screenshot Sweeper", comment: "menu")) {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+        .padding(8)
+        .frame(width: 240)
+        .sheet(isPresented: $showingConfirm) {
+            ConfirmCleanupView(count: viewModel.matchCount, destinationDescription: destinationDescription()) {
+                let cleaned = viewModel.cleanNow()
+                toast(cleaned: cleaned)
+                showingConfirm = false
+            } onCancel: {
+                showingConfirm = false
+            }
+        }
+    }
+
+    private func destinationDescription() -> String {
+        switch viewModel.settings.destinationMode {
+        case .trash:
+            return NSLocalizedString("Trash", comment: "dest")
+        case .folder(let bookmark):
+            if let url = FolderAccess.resolveBookmark(bookmark) {
+                return url.path
+            }
+            return NSLocalizedString("Folder", comment: "dest")
+        }
+    }
+
+    private func lastRunText() -> String {
+        if let date = viewModel.settings.lastRun {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .full
+            return formatter.localizedString(for: date, relativeTo: Date())
+        } else {
+            return NSLocalizedString("Never", comment: "status")
+        }
+    }
+
+    private func toast(cleaned: Int) {
+        guard cleaned > 0 else { return }
+        toastMessage = String(format: NSLocalizedString("Moved %d file%@", comment: "toast"), cleaned, cleaned == 1 ? "" : "s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { toastMessage = nil }
+        }
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/PreferencesView.swift
+++ b/Sources/ScreenshotSweeper/Views/PreferencesView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import AppKit
+
+struct PreferencesView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @State private var showingConfirm = false
+    @State private var destChoice: DestinationChoice
+
+    init(viewModel: AppViewModel) {
+        self.viewModel = viewModel
+        switch viewModel.settings.destinationMode {
+        case .trash: _destChoice = State(initialValue: .trash)
+        case .folder: _destChoice = State(initialValue: .folder)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Form {
+                scheduleSection
+                destinationSection
+                filterSection
+                actionsSection
+                aboutSection
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .sheet(isPresented: $showingConfirm) {
+            ConfirmCleanupView(count: viewModel.matchCount, destinationDescription: destinationDescription()) {
+                viewModel.cleanNow()
+                showingConfirm = false
+            } onCancel: {
+                showingConfirm = false
+            }
+        }
+    }
+
+    private var scheduleSection: some View {
+        Section(header: Text(NSLocalizedString("Schedule", comment: "section"))) {
+            Toggle(NSLocalizedString("Enable daily cleanup", comment: "toggle"), isOn: $viewModel.settings.cleanupEnabled)
+                .onChange(of: viewModel.settings.cleanupEnabled) { _ in
+                    viewModel.settings.save()
+                    viewModel.updateSchedule()
+                }
+            DatePicker(NSLocalizedString("Time", comment: "time"), selection: cleanupTimeBinding, displayedComponents: .hourAndMinute)
+            Text(NSLocalizedString("Sweeps your Desktop screenshots once per day.", comment: "help"))
+                .font(.caption)
+        }
+    }
+
+    private var destinationSection: some View {
+        Section(header: Text(NSLocalizedString("Destination", comment: "section"))) {
+            Picker("", selection: $destChoice) {
+                Text(NSLocalizedString("Move to Trash", comment: "dest")).tag(DestinationChoice.trash)
+                Text(NSLocalizedString("Move to Folder…", comment: "dest")).tag(DestinationChoice.folder)
+            }
+            .pickerStyle(.radioGroup)
+            .onChange(of: destChoice) { newValue in
+                switch newValue {
+                case .trash:
+                    viewModel.settings.destinationMode = .trash
+                    viewModel.settings.save()
+                case .folder:
+                    if case .folder = viewModel.settings.destinationMode {
+                        break
+                    } else {
+                        chooseFolder()
+                    }
+                }
+            }
+
+            if case .folder(let bookmark) = viewModel.settings.destinationMode {
+                if let url = FolderAccess.resolveBookmark(bookmark) {
+                    HStack {
+                        Text(url.path)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Button(NSLocalizedString("Change", comment: "button")) {
+                            chooseFolder()
+                        }
+                        Button(NSLocalizedString("Reveal", comment: "button")) {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                } else {
+                    Text(NSLocalizedString("Selected folder unavailable", comment: "warning"))
+                        .foregroundColor(.red)
+                    Button(NSLocalizedString("Re-select", comment: "button")) {
+                        chooseFolder()
+                    }
+                }
+            }
+        }
+    }
+
+    private var filterSection: some View {
+        Section(header: Text(NSLocalizedString("Filter", comment: "section"))) {
+            TextField(NSLocalizedString("Prefix", comment: "field"), text: $viewModel.settings.prefix)
+                .onChange(of: viewModel.settings.prefix) { _ in
+                    viewModel.settings.save()
+                    viewModel.refreshMatchCount()
+                }
+            Toggle(NSLocalizedString("Case-sensitive match", comment: "toggle"), isOn: $viewModel.settings.isCaseSensitive)
+                .onChange(of: viewModel.settings.isCaseSensitive) { _ in
+                    viewModel.settings.save()
+                    viewModel.refreshMatchCount()
+                }
+            Text(NSLocalizedString("Only files on Desktop whose names start with this prefix will be cleaned.", comment: "help"))
+                .font(.caption)
+            Text(String(format: NSLocalizedString("Currently matching %d file(s) on Desktop.", comment: "preview"), viewModel.matchCount))
+                .font(.footnote)
+                .padding(.top, 4)
+        }
+    }
+
+    private var actionsSection: some View {
+        Section(header: Text(NSLocalizedString("Actions", comment: "section"))) {
+            Button(NSLocalizedString("Clean Now…", comment: "button")) {
+                viewModel.refreshMatchCount()
+                showingConfirm = true
+            }
+            .disabled(viewModel.matchCount == 0)
+            if viewModel.matchCount == 0 {
+                Text(NSLocalizedString("No matching files found.", comment: "hint"))
+                    .font(.caption)
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        Section(header: Text(NSLocalizedString("About", comment: "section"))) {
+            Text(appNameVersion())
+            Text(NSLocalizedString("No files are uploaded; this app only moves files on your Mac.", comment: "about"))
+                .font(.caption)
+        }
+    }
+
+    private var cleanupTimeBinding: Binding<Date> {
+        Binding<Date>(
+            get: {
+                Calendar.current.date(from: viewModel.settings.cleanupTime) ?? Date()
+            },
+            set: { newDate in
+                let comps = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+                viewModel.settings.cleanupTime = comps
+                viewModel.settings.save()
+                viewModel.updateSchedule()
+            }
+        )
+    }
+
+    private func chooseFolder() {
+        if let bookmark = FolderAccess.selectFolder() {
+            viewModel.settings.destinationMode = .folder(bookmark: bookmark)
+            viewModel.settings.save()
+        } else {
+            destChoice = .trash
+            viewModel.settings.destinationMode = .trash
+            viewModel.settings.save()
+        }
+    }
+
+    private func destinationDescription() -> String {
+        switch viewModel.settings.destinationMode {
+        case .trash:
+            return NSLocalizedString("Trash", comment: "dest")
+        case .folder(let bookmark):
+            if let url = FolderAccess.resolveBookmark(bookmark) {
+                return url.path
+            }
+            return NSLocalizedString("Folder", comment: "dest")
+        }
+    }
+
+    private func appNameVersion() -> String {
+        let name = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Screenshot Sweeper"
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+        return "\(name) \(version)"
+    }
+}
+
+enum DestinationChoice: Hashable {
+    case trash
+    case folder
+}


### PR DESCRIPTION
## Summary
- Track last cleanup time and expose match count utilities
- Add two-step cleanup confirmation and toast feedback
- Build full menu bar and preferences UI with scheduling, destination, and filtering controls

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68b1daeebc6c832aa2d98d7bfd8ff71e