### PR TITLE
feat: implement menu bar and preferences UI

### DIFF
--- a/Sources/ScreenshotSweeper/Models/Settings.swift
+++ b/Sources/ScreenshotSweeper/Models/Settings.swift
@@ -13,6 +13,7 @@ struct Settings: Codable {
     var prefix: String = "Screenshot"
     var isCaseSensitive: Bool = true
     var totalCleaned: Int = 0
+    var lastRun: Date? = nil
 }
 
 extension Settings {

--- a/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
+++ b/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
@@ -7,7 +7,7 @@ struct ScreenshotSweeperApp: App {
     @State private var showingPreferences = false
 
     var body: some Scene {
-        MenuBarExtra("Screenshot Sweeper", systemImage: "scissors") {
+        MenuBarExtra("Screenshot Sweeper", systemImage: "trash.circle") {
             MenuBarView(viewModel: viewModel, showingPreferences: $showingPreferences)
         }
         .menuBarExtraStyle(.window)

--- a/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
+++ b/Sources/ScreenshotSweeper/ViewModels/AppViewModel.swift
@@ -4,16 +4,19 @@ import os.log
 
 final class AppViewModel: ObservableObject {
     @Published var settings: Settings
+    @Published var matchCount: Int = 0
     private let scheduler = Scheduler()
     private let cleanupService = CleanupService()
     private let logger = Logger(subsystem: "ScreenshotSweeper", category: "ViewModel")
 
     init() {
         settings = Settings.load()
+        refreshMatchCount()
         scheduleCleanup()
     }
 
-    func cleanNow() {
+    @discardableResult
+    func cleanNow() -> Int {
         let destination: CleanupService.Destination
         switch settings.destinationMode {
         case .trash:
@@ -30,16 +33,29 @@ final class AppViewModel: ObservableObject {
         let count = cleanupService.performCleanup(prefix: settings.prefix, isCaseSensitive: settings.isCaseSensitive, destination: destination)
         if count > 0 {
             settings.totalCleaned += count
-            settings.save()
         }
+        settings.lastRun = Date()
+        settings.save()
+        refreshMatchCount()
+        return count
+    }
+
+    func refreshMatchCount() {
+        matchCount = countMatches(prefix: settings.prefix, isCaseSensitive: settings.isCaseSensitive)
+    }
+
+    func updateSchedule() {
+        scheduler.invalidate()
+        scheduleCleanup()
     }
 
     private func scheduleCleanup() {
         guard settings.cleanupEnabled else { return }
         let next = nextCleanupDate()
         scheduler.schedule(at: next) { [weak self] in
-            self?.cleanNow()
-            self?.scheduleCleanup()
+            guard let self = self else { return }
+            _ = self.cleanNow()
+            self.scheduleCleanup()
         }
     }
 
@@ -51,5 +67,58 @@ final class AppViewModel: ObservableObject {
             date = cal.date(byAdding: .day, value: 1, to: date) ?? date
         }
         return date
+    }
+
+    private func countMatches(prefix: String, isCaseSensitive: Bool) -> Int {
+        let fm = FileManager.default
+        guard let desktop = fm.urls(for: .desktopDirectory, in: .userDomainMask).first else { return 0 }
+        let exts = ["png", "jpg", "jpeg", "heic", "tiff"]
+        do {
+            let items = try fm.contentsOfDirectory(at: desktop, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+            return items.filter { url in
+                guard exts.contains(url.pathExtension.lowercased()) else { return false }
+                let name = url.lastPathComponent
+                if isCaseSensitive {
+                    return name.hasPrefix(prefix)
+                } else {
+                    return name.lowercased().hasPrefix(prefix.lowercased())
+                }
+            }.count
+        } catch {
+            logger.error("Error counting matches: \(error.localizedDescription, privacy: .public)")
+            return 0
+        }
+    }
+
+    var destinationDescription: String {
+        switch settings.destinationMode {
+        case .trash:
+            return NSLocalizedString("Trash", comment: "Destination trash")
+        case .folder(let bookmark):
+            if let url = FolderAccess.resolveBookmark(bookmark) {
+                return url.lastPathComponent
+            } else {
+                return NSLocalizedString("Folder", comment: "Destination folder")
+            }
+        }
+    }
+
+    var destinationURL: URL? {
+        switch settings.destinationMode {
+        case .trash:
+            return nil
+        case .folder(let bookmark):
+            return FolderAccess.resolveBookmark(bookmark)
+        }
+    }
+
+    var lastRunDescription: String {
+        if let last = settings.lastRun {
+            let fmt = RelativeDateTimeFormatter()
+            fmt.unitsStyle = .abbreviated
+            return fmt.localizedString(for: last, relativeTo: Date())
+        } else {
+            return NSLocalizedString("Never", comment: "Never run")
+        }
     }
 }

--- a/Sources/ScreenshotSweeper/Views/CleanConfirmationView.swift
+++ b/Sources/ScreenshotSweeper/Views/CleanConfirmationView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct CleanConfirmationView: View {
+    let count: Int
+    let destination: String
+    @Binding var isPresented: Bool
+    var onConfirm: () -> Void
+
+    @State private var step: Int = 1
+    @State private var acknowledged = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if step == 1 {
+                Text("You're about to clean \(count) screenshot(s) from Desktop.")
+                    .multilineTextAlignment(.center)
+                HStack {
+                    Button("Cancel") { isPresented = false }
+                    Spacer()
+                    Button("Continue") { step = 2 }
+                        .keyboardShortcut(.defaultAction)
+                }
+            } else {
+                Text("These files will be moved to \(destination).")
+                    .multilineTextAlignment(.center)
+                Toggle("I understand", isOn: $acknowledged)
+                HStack {
+                    Button("Cancel") { isPresented = false }
+                    Spacer()
+                    Button("Confirm") {
+                        onConfirm()
+                        isPresented = false
+                        step = 1
+                        acknowledged = false
+                    }
+                    .disabled(!acknowledged)
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+        .padding(24)
+        .frame(width: 320)
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/MenuBarView.swift
+++ b/Sources/ScreenshotSweeper/Views/MenuBarView.swift
@@ -1,32 +1,56 @@
 import SwiftUI
+import AppKit
 
 struct MenuBarView: View {
     @ObservedObject var viewModel: AppViewModel
     @Binding var showingPreferences: Bool
-    @State private var confirmCleanup = false
+    @State private var showingConfirm = false
+    @State private var showSuccess = false
+    @State private var lastCleanCount = 0
 
     var body: some View {
-        VStack {
-            Text("Total cleaned: \(viewModel.settings.totalCleaned)")
-                .padding(.horizontal)
-            Divider()
+        VStack(alignment: .leading, spacing: 8) {
             Button("Clean Now…") {
-                confirmCleanup = true
+                viewModel.refreshMatchCount()
+                showingConfirm = true
             }
-            .alert("Clean Desktop Screenshots?", isPresented: $confirmCleanup) {
-                Button("Cancel", role: .cancel) {}
-                Button("Clean", role: .destructive) {
-                    viewModel.cleanNow()
-                }
-            } message: {
-                Text("This will move matching screenshots according to your settings.")
-            }
+                .keyboardShortcut(.return, modifiers: [])
+            Text("Total cleaned (all-time): \(viewModel.settings.totalCleaned)")
+                .padding(.top, 4)
+            Text("Last run: \(viewModel.lastRunDescription)")
             Divider()
-            Button("Preferences…") {
-                showingPreferences = true
-            }
-            Button("Quit") {
+            Toggle("Daily cleanup", isOn: $viewModel.settings.cleanupEnabled)
+                .onChange(of: viewModel.settings.cleanupEnabled) { _ in
+                    viewModel.settings.save()
+                    viewModel.updateSchedule()
+                }
+            Button("Open Preferences…") { showingPreferences = true }
+                .keyboardShortcut(",")
+            Button("Quit Screenshot Sweeper") {
                 NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+        .padding(12)
+        .frame(minWidth: 220)
+        .sheet(isPresented: $showingConfirm) {
+            CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
+                let count = viewModel.cleanNow()
+                lastCleanCount = count
+                if count > 0 {
+                    withAnimation(.spring()) { showSuccess = true }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        withAnimation { showSuccess = false }
+                    }
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            if showSuccess {
+                Text("Moved \(lastCleanCount) file(s)")
+                    .padding(6)
+                    .background(.thinMaterial, in: Capsule())
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
     }

--- a/Sources/ScreenshotSweeper/Views/PreferencesView.swift
+++ b/Sources/ScreenshotSweeper/Views/PreferencesView.swift
@@ -1,11 +1,155 @@
 import SwiftUI
+import AppKit
 
 struct PreferencesView: View {
     @ObservedObject var viewModel: AppViewModel
+    @State private var showingConfirm = false
+    @State private var showSuccess = false
+    @State private var lastCleanCount = 0
+    @State private var cleanupTime: Date = Calendar.current.date(from: AppViewModel.defaultDateComponents) ?? Date()
+    @State private var destinationChoice: Int = 0
+
+    init(viewModel: AppViewModel) {
+        self.viewModel = viewModel
+        _cleanupTime = State(initialValue: Calendar.current.date(from: viewModel.settings.cleanupTime) ?? Date())
+        switch viewModel.settings.destinationMode {
+        case .trash:
+            _destinationChoice = State(initialValue: 0)
+        case .folder:
+            _destinationChoice = State(initialValue: 1)
+        }
+    }
 
     var body: some View {
-        Text("Preferences go here")
-            .padding()
-            // TODO: Build out UI in later prompt
+        Form {
+            Section("Schedule") {
+                Toggle("Enable daily cleanup", isOn: $viewModel.settings.cleanupEnabled)
+                    .onChange(of: viewModel.settings.cleanupEnabled) { _ in
+                        viewModel.settings.save()
+                        viewModel.updateSchedule()
+                    }
+                DatePicker("Time", selection: $cleanupTime, displayedComponents: .hourAndMinute)
+                    .onChange(of: cleanupTime) { newValue in
+                        let comps = Calendar.current.dateComponents([.hour, .minute], from: newValue)
+                        viewModel.settings.cleanupTime = comps
+                        viewModel.settings.save()
+                        viewModel.updateSchedule()
+                    }
+                    .disabled(!viewModel.settings.cleanupEnabled)
+                Text("Sweeps your Desktop screenshots once per day.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+            Section("Destination") {
+                Picker("", selection: $destinationChoice) {
+                    Text("Move to Trash").tag(0)
+                    Text("Move to Folder…").tag(1)
+                }
+                .pickerStyle(.radioGroup)
+                .onChange(of: destinationChoice) { newValue in
+                    if newValue == 0 {
+                        viewModel.settings.destinationMode = .trash
+                        viewModel.settings.save()
+                    }
+                }
+
+                if destinationChoice == 1 {
+                    if let url = viewModel.destinationURL {
+                        HStack {
+                            Text(url.path)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Button("Change") { chooseFolder() }
+                            Button("Reveal in Finder") {
+                                NSWorkspace.shared.activateFileViewerSelecting([url])
+                            }
+                        }
+                    } else {
+                        HStack {
+                            Text("Folder unavailable")
+                                .foregroundColor(.red)
+                            Button("Re-select") { chooseFolder() }
+                        }
+                    }
+                }
+            }
+
+            Section("Filter") {
+                TextField("Prefix", text: $viewModel.settings.prefix)
+                    .onChange(of: viewModel.settings.prefix) { _ in
+                        viewModel.settings.save()
+                        viewModel.refreshMatchCount()
+                    }
+                Toggle("Case-sensitive match", isOn: $viewModel.settings.isCaseSensitive)
+                    .onChange(of: viewModel.settings.isCaseSensitive) { _ in
+                        viewModel.settings.save()
+                        viewModel.refreshMatchCount()
+                    }
+                Text("Only files on Desktop whose names start with this prefix will be cleaned.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+            Text("Currently matching \(viewModel.matchCount) file(s) on Desktop.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+
+            Section("Actions") {
+                Button("Clean Now…") { showingConfirm = true }
+                    .disabled(viewModel.matchCount == 0)
+                if viewModel.matchCount == 0 {
+                    Text("No matching files found.")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Section("About") {
+                let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+                Text("Screenshot Sweeper \(version)")
+                Text("No files are uploaded; this app only moves files on your Mac.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .sheet(isPresented: $showingConfirm) {
+            CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
+                let count = viewModel.cleanNow()
+                lastCleanCount = count
+                if count > 0 {
+                    withAnimation(.spring()) { showSuccess = true }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        withAnimation { showSuccess = false }
+                    }
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            if showSuccess {
+                Text("Moved \(lastCleanCount) file(s)")
+                    .padding(6)
+                    .background(.thinMaterial, in: Capsule())
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .onAppear {
+            viewModel.refreshMatchCount()
+        }
     }
+
+    private func chooseFolder() {
+        if let bm = FolderAccess.selectFolder() {
+            viewModel.settings.destinationMode = .folder(bookmark: bm)
+            viewModel.settings.save()
+            viewModel.refreshMatchCount()
+        }
+    }
+}
+
+extension AppViewModel {
+    static var defaultDateComponents: DateComponents { DateComponents(hour: 23, minute: 59) }
 }


### PR DESCRIPTION
## Summary
- add last run tracking and match counting to settings and view model
- design two-step cleaning confirmation with reusable view
- build menu bar and preferences UI with scheduling, destination, filter, and live match preview

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b1e08fc334832a9052c9a61c5997fe