### PR TITLE
Improve scheduling, permissions, and add test coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,11 @@ let package = Package(
                 .linkedFramework("AppKit"),
                 .linkedFramework("SwiftUI")
             ]
+        ),
+        .testTarget(
+            name: "ScreenshotSweeperTests",
+            dependencies: ["ScreenshotSweeper"],
+            path: "Tests/ScreenshotSweeperTests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Screenshot Sweeper
+
+Screenshot Sweeper moves Desktop screenshots to the Trash or a folder each day.
+
+## Permissions
+The app needs permission to access your Desktop. If files are not being moved,
+open **System Settings → Privacy & Security → Files and Folders** and allow
+*Screenshot Sweeper* to access the Desktop and any destination folder.
+
+## Changing prefix and destination
+Use **Preferences…** from the menu bar to change the screenshot prefix, toggle
+case sensitivity, pick a destination (Trash or a folder), and adjust the cleanup
+time. Folder selections are stored as security‑scoped bookmarks; if access
+becomes invalid, the app will ask you to choose the folder again.

--- a/Sources/ScreenshotSweeper/Models/Settings.swift
+++ b/Sources/ScreenshotSweeper/Models/Settings.swift
@@ -17,7 +17,11 @@ struct Settings: Codable {
 }
 
 extension Settings {
-    private static let defaultsKey = "settings"
+    /// Namespace UserDefaults keys using the bundle identifier.
+    private static var defaultsKey: String {
+        let bundle = Bundle.main.bundleIdentifier ?? "com.example.screenshotsweeper"
+        return "\(bundle).settings"
+    }
 
     static func load() -> Settings {
         let defaults = UserDefaults.standard

--- a/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
+++ b/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import os.log
+import AppKit
 
 @main
 struct ScreenshotSweeperApp: App {
@@ -13,6 +14,9 @@ struct ScreenshotSweeperApp: App {
         .menuBarExtraStyle(.window)
         .sheet(isPresented: $showingPreferences) {
             PreferencesView(viewModel: viewModel)
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)) { _ in
+            viewModel.recomputeSchedule()
         }
     }
 }

--- a/Sources/ScreenshotSweeper/Services/CleanupService.swift
+++ b/Sources/ScreenshotSweeper/Services/CleanupService.swift
@@ -1,51 +1,81 @@
 import Foundation
 import os.log
 
+struct CleanupResult { let cleaned: Int; let skipped: Int }
+
 struct CleanupService {
     enum Destination {
         case trash
         case folder(URL)
     }
 
-    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "Cleanup")
+    private let logger = Logger(subsystem: "ScreenshotSweeper", category: "cleanup")
+    private let permLogger = Logger(subsystem: "ScreenshotSweeper", category: "permissions")
 
-    func performCleanup(prefix: String, isCaseSensitive: Bool, destination: Destination) -> Int {
+    /// Returns matching screenshot URLs without moving them.
+    func findMatches(in directory: URL, prefix: String, isCaseSensitive: Bool) -> [URL] {
         let fm = FileManager.default
-        guard let desktop = fm.urls(for: .desktopDirectory, in: .userDomainMask).first else {
-            logger.error("Could not resolve Desktop directory")
-            return 0
-        }
         let exts = ["png", "jpg", "jpeg", "heic", "tiff"]
-        var cleaned = 0
+        let items: [URL]
         do {
-            let items = try fm.contentsOfDirectory(at: desktop, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
-            for url in items {
-                guard exts.contains(url.pathExtension.lowercased()) else { continue }
-                let name = url.lastPathComponent
-                let matches: Bool
-                if isCaseSensitive {
-                    matches = name.hasPrefix(prefix)
-                } else {
-                    matches = name.lowercased().hasPrefix(prefix.lowercased())
-                }
-                guard matches else { continue }
-                do {
-                    switch destination {
-                    case .trash:
-                        try fm.trashItem(at: url, resultingItemURL: nil)
-                    case .folder(let folderURL):
-                        let dest = conflictSafeURL(for: url, in: folderURL)
-                        try fm.moveItem(at: url, to: dest)
-                    }
-                    cleaned += 1
-                } catch {
-                    logger.error("Failed to move \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                }
-            }
+            items = try fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
         } catch {
-            logger.error("Error reading Desktop: \(error.localizedDescription, privacy: .public)")
+            permLogger.error("Cannot read directory \(directory.path, privacy: .public). Check permissions in System Settings → Privacy & Security → Files and Folders")
+            return []
         }
-        return cleaned
+        return items.filter { url in
+            guard exts.contains(url.pathExtension.lowercased()) else { return false }
+            let name = url.lastPathComponent
+            if isCaseSensitive {
+                return name.hasPrefix(prefix)
+            } else {
+                return name.lowercased().hasPrefix(prefix.lowercased())
+            }
+        }
+    }
+
+    /// Performs cleanup and returns counts. Throws if destination permission fails.
+    func performCleanup(prefix: String, isCaseSensitive: Bool, destination: Destination, directory: URL? = nil) throws -> CleanupResult {
+        let fm = FileManager.default
+        let dirURL: URL
+        if let directory = directory {
+            dirURL = directory
+        } else if let desktop = fm.urls(for: .desktopDirectory, in: .userDomainMask).first {
+            dirURL = desktop
+        } else {
+            logger.error("Could not resolve Desktop directory")
+            return CleanupResult(cleaned: 0, skipped: 0)
+        }
+
+        let matches = findMatches(in: dirURL, prefix: prefix, isCaseSensitive: isCaseSensitive)
+        var cleaned = 0
+        var skipped = 0
+        for url in matches {
+            do {
+                switch destination {
+                case .trash:
+                    try fm.trashItem(at: url, resultingItemURL: nil)
+                case .folder(let folderURL):
+                    let dest = conflictSafeURL(for: url, in: folderURL)
+                    try fm.moveItem(at: url, to: dest)
+                }
+                cleaned += 1
+            } catch {
+                let ns = error as NSError
+                if ns.domain == NSCocoaErrorDomain && (ns.code == NSFileWriteNoPermissionError || ns.code == NSFileReadNoPermissionError) {
+                    permLogger.error("Permission denied while moving \(url.path, privacy: .public)")
+                    throw error
+                }
+                if ns.domain == NSPOSIXErrorDomain && ns.code == Int(EBUSY) {
+                    skipped += 1
+                    logger.info("File busy, skipping \(url.lastPathComponent, privacy: .public)")
+                    continue
+                }
+                skipped += 1
+                logger.error("Failed to move \(url.path, privacy: .public): \(ns.localizedDescription, privacy: .public)")
+            }
+        }
+        return CleanupResult(cleaned: cleaned, skipped: skipped)
     }
 
     private func conflictSafeURL(for url: URL, in folder: URL) -> URL {

--- a/Sources/ScreenshotSweeper/Services/FolderAccess.swift
+++ b/Sources/ScreenshotSweeper/Services/FolderAccess.swift
@@ -17,8 +17,12 @@ enum FolderAccess {
         }
     }
 
+    /// Resolves a bookmark. If the bookmark is stale, nil is returned so the caller can prompt the user again.
     static func resolveBookmark(_ data: Data) -> URL? {
         var isStale = false
-        return try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &isStale)
+        guard let url = try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &isStale) else {
+            return nil
+        }
+        return isStale ? nil : url
     }
 }

--- a/Sources/ScreenshotSweeper/Utilities/NextRunCalculator.swift
+++ b/Sources/ScreenshotSweeper/Utilities/NextRunCalculator.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Utility to compute next and previous cleanup dates given a target time.
+struct NextRunCalculator {
+    /// Returns the next date matching the provided hour/minute components.
+    static func nextDate(for components: DateComponents, from now: Date = Date(), calendar: Calendar = .current) -> Date {
+        var comps = components
+        comps.second = 0
+        if let next = calendar.nextDate(after: now, matching: comps, matchingPolicy: .nextTimePreservingSmallerComponents) {
+            return next
+        }
+        return now
+    }
+
+    /// Returns the most recent past date matching the provided components.
+    static func previousDate(for components: DateComponents, from now: Date = Date(), calendar: Calendar = .current) -> Date? {
+        var comps = components
+        comps.second = 0
+        let today = calendar.date(bySettingHour: comps.hour ?? 0, minute: comps.minute ?? 0, second: 0, of: now) ?? now
+        if today <= now {
+            return today
+        }
+        return calendar.date(byAdding: .day, value: -1, to: today)
+    }
+}

--- a/Sources/ScreenshotSweeper/Views/MenuBarView.swift
+++ b/Sources/ScreenshotSweeper/Views/MenuBarView.swift
@@ -7,6 +7,7 @@ struct MenuBarView: View {
     @State private var showingConfirm = false
     @State private var showSuccess = false
     @State private var lastCleanCount = 0
+    @State private var lastSkippedCount = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -35,9 +36,10 @@ struct MenuBarView: View {
         .frame(minWidth: 220)
         .sheet(isPresented: $showingConfirm) {
             CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
-                let count = viewModel.cleanNow()
-                lastCleanCount = count
-                if count > 0 {
+                let result = viewModel.cleanNow()
+                lastCleanCount = result.cleaned
+                lastSkippedCount = result.skipped
+                if result.cleaned > 0 || result.skipped > 0 {
                     withAnimation(.spring()) { showSuccess = true }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                         withAnimation { showSuccess = false }
@@ -47,7 +49,7 @@ struct MenuBarView: View {
         }
         .overlay(alignment: .top) {
             if showSuccess {
-                Text("Moved \(lastCleanCount) file(s)")
+                Text("Moved \(lastCleanCount) file(s), skipped \(lastSkippedCount)")
                     .padding(6)
                     .background(.thinMaterial, in: Capsule())
                     .transition(.move(edge: .top).combined(with: .opacity))

--- a/Sources/ScreenshotSweeper/Views/PreferencesView.swift
+++ b/Sources/ScreenshotSweeper/Views/PreferencesView.swift
@@ -6,6 +6,7 @@ struct PreferencesView: View {
     @State private var showingConfirm = false
     @State private var showSuccess = false
     @State private var lastCleanCount = 0
+    @State private var lastSkippedCount = 0
     @State private var cleanupTime: Date = Calendar.current.date(from: AppViewModel.defaultDateComponents) ?? Date()
     @State private var destinationChoice: Int = 0
 
@@ -118,9 +119,10 @@ struct PreferencesView: View {
         .frame(width: 400)
         .sheet(isPresented: $showingConfirm) {
             CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
-                let count = viewModel.cleanNow()
-                lastCleanCount = count
-                if count > 0 {
+                let result = viewModel.cleanNow()
+                lastCleanCount = result.cleaned
+                lastSkippedCount = result.skipped
+                if result.cleaned > 0 || result.skipped > 0 {
                     withAnimation(.spring()) { showSuccess = true }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                         withAnimation { showSuccess = false }
@@ -130,7 +132,7 @@ struct PreferencesView: View {
         }
         .overlay(alignment: .top) {
             if showSuccess {
-                Text("Moved \(lastCleanCount) file(s)")
+                Text("Moved \(lastCleanCount) file(s), skipped \(lastSkippedCount)")
                     .padding(6)
                     .background(.thinMaterial, in: Capsule())
                     .transition(.move(edge: .top).combined(with: .opacity))

--- a/Tests/ScreenshotSweeperTests/ConflictSafeRenamingTests.swift
+++ b/Tests/ScreenshotSweeperTests/ConflictSafeRenamingTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import ScreenshotSweeper
+
+final class ConflictSafeRenamingTests: XCTestCase {
+    func testRenaming() throws {
+        let src = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let dest = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: src, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: src)
+            try? FileManager.default.removeItem(at: dest)
+        }
+        let fm = FileManager.default
+        fm.createFile(atPath: src.appendingPathComponent("Screenshot.png").path, contents: Data())
+        // Existing file in destination
+        fm.createFile(atPath: dest.appendingPathComponent("Screenshot.png").path, contents: Data())
+
+        let service = CleanupService()
+        let result = try service.performCleanup(prefix: "Screenshot", isCaseSensitive: true, destination: .folder(dest), directory: src)
+        XCTAssertEqual(result.cleaned, 1)
+        XCTAssertTrue(fm.fileExists(atPath: dest.appendingPathComponent("Screenshot-1.png").path))
+    }
+}

--- a/Tests/ScreenshotSweeperTests/DryRunFinderTests.swift
+++ b/Tests/ScreenshotSweeperTests/DryRunFinderTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import ScreenshotSweeper
+
+final class DryRunFinderTests: XCTestCase {
+    func testDryRunDoesNotMove() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fm = FileManager.default
+        let file = dir.appendingPathComponent("Screenshot1.png")
+        fm.createFile(atPath: file.path, contents: Data())
+        let service = CleanupService()
+        let matches = service.findMatches(in: dir, prefix: "Screenshot", isCaseSensitive: true)
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertTrue(fm.fileExists(atPath: file.path))
+    }
+}

--- a/Tests/ScreenshotSweeperTests/NextRunCalculatorTests.swift
+++ b/Tests/ScreenshotSweeperTests/NextRunCalculatorTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import ScreenshotSweeper
+
+final class NextRunCalculatorTests: XCTestCase {
+    func testNextDateAroundMidnight() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = cal.date(from: DateComponents(year: 2023, month: 5, day: 1, hour: 23, minute: 58))!
+        let target = DateComponents(hour: 23, minute: 59)
+        let next = NextRunCalculator.nextDate(for: target, from: now, calendar: cal)
+        XCTAssertEqual(cal.component(.day, from: next), 1)
+        XCTAssertEqual(cal.component(.hour, from: next), 23)
+        XCTAssertEqual(cal.component(.minute, from: next), 59)
+
+        let after = cal.date(from: DateComponents(year: 2023, month: 5, day: 1, hour: 23, minute: 59, second: 30))!
+        let next2 = NextRunCalculator.nextDate(for: target, from: after, calendar: cal)
+        XCTAssertEqual(cal.component(.day, from: next2), 2)
+    }
+
+    func testDSTForwardJump() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "America/New_York")!
+        let now = cal.date(from: DateComponents(year: 2023, month: 3, day: 12, hour: 1, minute: 0))!
+        let target = DateComponents(hour: 2, minute: 30)
+        let next = NextRunCalculator.nextDate(for: target, from: now, calendar: cal)
+        // 2:30 AM does not exist on this day; expect 3:30 AM
+        XCTAssertEqual(cal.component(.day, from: next), 12)
+        XCTAssertEqual(cal.component(.hour, from: next), 3)
+    }
+}

--- a/Tests/ScreenshotSweeperTests/PrefixFilteringTests.swift
+++ b/Tests/ScreenshotSweeperTests/PrefixFilteringTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import ScreenshotSweeper
+
+final class PrefixFilteringTests: XCTestCase {
+    func testCaseSensitive() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fm = FileManager.default
+        fm.createFile(atPath: dir.appendingPathComponent("Screenshot1.png").path, contents: Data())
+        fm.createFile(atPath: dir.appendingPathComponent("screenshot2.png").path, contents: Data())
+        let service = CleanupService()
+        let matches = service.findMatches(in: dir, prefix: "Screenshot", isCaseSensitive: true)
+        XCTAssertEqual(matches.count, 1)
+    }
+
+    func testCaseInsensitive() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fm = FileManager.default
+        fm.createFile(atPath: dir.appendingPathComponent("Screenshot1.png").path, contents: Data())
+        fm.createFile(atPath: dir.appendingPathComponent("screenshot2.png").path, contents: Data())
+        let service = CleanupService()
+        let matches = service.findMatches(in: dir, prefix: "Screenshot", isCaseSensitive: false)
+        XCTAssertEqual(matches.count, 2)
+    }
+
+    func testEmptyPrefixMatchesAll() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fm = FileManager.default
+        fm.createFile(atPath: dir.appendingPathComponent("Screenshot1.png").path, contents: Data())
+        fm.createFile(atPath: dir.appendingPathComponent("Foo.png").path, contents: Data())
+        let service = CleanupService()
+        let matches = service.findMatches(in: dir, prefix: "", isCaseSensitive: true)
+        XCTAssertEqual(matches.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- namespace UserDefaults keys and persist metrics
- handle security-scoped bookmarks and permission errors
- add scheduler wake handling, missed-run logic, and dry-run matcher
- surface skipped files and add unit tests for matching, scheduling, and renaming

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68b1e41f5f5c832aa9368267f1cfd0e6