### PR TITLE
Improve prefix editing and confirmation flow

### DIFF
--- a/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
+++ b/Sources/ScreenshotSweeper/ScreenshotSweeperApp.swift
@@ -18,7 +18,6 @@ struct ScreenshotSweeperApp: App {
         Window("Preferences", id: "preferences") {
             PreferencesView(viewModel: viewModel)
         }
-        .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 400, height: 600)
     }

--- a/Sources/ScreenshotSweeper/Views/MenuBarView.swift
+++ b/Sources/ScreenshotSweeper/Views/MenuBarView.swift
@@ -10,41 +10,47 @@ struct MenuBarView: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Button("Clean Now…") {
-                viewModel.refreshMatchCount()
-                showingConfirm = true
-            }
-                .keyboardShortcut(.return, modifiers: [])
-            Text("Total cleaned (all-time): \(viewModel.settings.totalCleaned)")
-                .padding(.top, 4)
-            Text("Last run: \(viewModel.lastRunDescription)")
-            Divider()
-            Toggle("Daily cleanup", isOn: $viewModel.settings.cleanupEnabled)
-                .onChange(of: viewModel.settings.cleanupEnabled) { _ in
-                    viewModel.settings.save()
-                    viewModel.updateSchedule()
+        ZStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Button("Clean Now…") {
+                    viewModel.refreshMatchCount()
+                    showingConfirm = true
                 }
-            Button("Open Preferences…") { 
-                openWindow(id: "preferences")
+                    .keyboardShortcut(.return, modifiers: [])
+                Text("Total cleaned (all-time): \(viewModel.settings.totalCleaned)")
+                    .padding(.top, 4)
+                Text("Last run: \(viewModel.lastRunDescription)")
+                Divider()
+                Toggle("Daily cleanup", isOn: $viewModel.settings.cleanupEnabled)
+                    .onChange(of: viewModel.settings.cleanupEnabled) { _ in
+                        viewModel.settings.save()
+                        viewModel.updateSchedule()
+                    }
+                Button("Open Preferences…") {
+                    openWindow(id: "preferences")
+                }
+                .keyboardShortcut(",")
+                Button("Quit Screenshot Sweeper") {
+                    NSApplication.shared.terminate(nil)
+                }
+                .keyboardShortcut("q")
             }
-            .keyboardShortcut(",")
-            Button("Quit Screenshot Sweeper") {
-                NSApplication.shared.terminate(nil)
-            }
-            .keyboardShortcut("q")
-        }
-        .padding(12)
-        .frame(minWidth: 220)
-        .sheet(isPresented: $showingConfirm) {
-            CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
-                let result = viewModel.cleanNow()
-                lastCleanCount = result.cleaned
-                lastSkippedCount = result.skipped
-                if result.cleaned > 0 || result.skipped > 0 {
-                    withAnimation(.spring()) { showSuccess = true }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        withAnimation { showSuccess = false }
+            .padding(12)
+            .frame(minWidth: 220)
+
+            if showingConfirm {
+                ZStack {
+                    Color.black.opacity(0.25).ignoresSafeArea()
+                    CleanConfirmationView(count: viewModel.matchCount, destination: viewModel.destinationDescription, isPresented: $showingConfirm) {
+                        let result = viewModel.cleanNow()
+                        lastCleanCount = result.cleaned
+                        lastSkippedCount = result.skipped
+                        if result.cleaned > 0 || result.skipped > 0 {
+                            withAnimation(.spring()) { showSuccess = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                withAnimation { showSuccess = false }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Allow editing screenshot prefix with dedicated state in Preferences
- Keep menu and preferences windows visible during cleanup confirmation
- Show standard window controls in Preferences window

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6b3648c832a827730ffa6fd9924